### PR TITLE
Added "I'm just saying"

### DIFF
--- a/src/Warnings.js
+++ b/src/Warnings.js
@@ -38,5 +38,14 @@ var WARNINGS = {
     { keyword: 'try',
       source:  'http://www.lifehack.org/articles/communication/7-things-not-to-say-and-7-things-to-start-saying.html',
       message: '"Do or do not. There is no try." --Yoda' },
+    { keyword: 'I\'m just saying',
+      source:  'http://101books.net/2012/03/02/7-annoying-words-that-should-die-a-horrible-death/',
+      message: 'I think what you’re saying is that you said something. If ' +
+               'you\'re using it to mitigate something that may be offensive or ' +
+               'embarassing, then don\'t say it. Say something else. Otherwise, '
+               'say what you\'re saying without the “just saying.” We already ' +
+               'know you’re saying it… after all, you just said it!' +
+               '--Jon Acuff', },
+    },
   ],
 };


### PR DESCRIPTION
A variation on the 'just' theme, but important in its own right. 'I'm just saying' is redundant at best ([I'm just saying] we should consider moving our meeting time... the sentence is fine without it), offensive at worst ("Maybe our meetings would be more efficient if Shannon didn't have to breastfeed at the conference table, I'm just saying." Ugh. Trying to mitigate something offensive doesn't make it less offensive. Don't say any of it). Either way, "I'm just saying" is something you shouldn't be saying.