### PR TITLE
Fixes broken input of modifier characters on MacOSX.

### DIFF
--- a/src/JustNotSorry.js
+++ b/src/JustNotSorry.js
@@ -39,10 +39,15 @@ var JustNotSorry = function() {
     var target = compose.$el.get(0);
     var observer = new MutationObserver(function() {
       var body = compose.dom('body');
+      // MacOSX allows typing these modifiers for characters. See http://guides.macrumors.com/Typing_with_extended_characters
+      var modifierCharacters = ["\u00A8", "\u02C6", "\u0384"];
       var caretPosition = body.caret('pos');
-      warningChecker.removeWarnings(body);
-      warningChecker.addWarnings(body);
-      body.caret('pos', caretPosition);
+      // Do not run checker if user inputted one of these modifiers.
+      if (caretPosition > 0 && !modifierCharacters.includes(body.text()[caretPosition-1])) {
+        warningChecker.removeWarnings(body);
+        warningChecker.addWarnings(body);
+        body.caret('pos', caretPosition);
+      }
     });
     observer.observe(target, {characterData: true, subtree: true});
   }


### PR DESCRIPTION
Fixes #25 by checking if the character next to the caret is one of MacOS X supported modifier characters. If this is the case the checker isn't run.

It also does not check if such a character is copy/pasted. However this has no negative effect as the checker will run again when the next character is input.

The modifiers are exhaustive according to http://guides.macrumors.com/Typing_with_extended_characters. If more are added they can easily be added to the `modifierCharacters` array.

## Further discussion
I would have preferred a solution where the special input state (OS is waiting for the second character) is detected but haven't found a way. For a Chrome Extension it looks like a normal character has been entered.