### PR TITLE
added some chatty/empty/weakening words and phrases

### DIFF
--- a/src/Warnings.js
+++ b/src/Warnings.js
@@ -4,28 +4,86 @@ var WARNINGS = {
       source:  'http://www.taramohr.com/8-ways-women-undermine-themselves-with-their-words/',
       message: '"Just" demeans what you have to say. "Just" shrinks your power. ' +
                'It\'s time to say goodbye to the justs. --Tara Sophia Mohr', },
+               
     { keyword: 'actually',
       source:  'http://www.taramohr.com/8-ways-women-undermine-themselves-with-their-words/',
       message: '"Actually" communicates a sense of surprise that you have ' +
                'something to say. Of course you want to add something. Of ' +
                'course you have questions. There\'s nothing surprising about ' +
                'it.  --Tara Sophia Mohr', },
+               
     { keyword: 'sorry',
       source:  'http://www.fastcompany.com/3032112/strong-female-lead/sorry-not-sorry-why-women-need-to-stop-apologizing-for-everything',
       message: 'Using "sorry" frequently undermines your gravitas and makes you ' +
                'appear unfit for leadership. --Sylvia Ann Hewlett', },
+               
     { keyword: 'apologize',
       source:  'http://www.fastcompany.com/3032112/strong-female-lead/sorry-not-sorry-why-women-need-to-stop-apologizing-for-everything',
       message: 'Apologizing unnecessarily puts you in a subservient position and ' +
                'makes people lose respect for you --Bonnie Marcus', },
-    { keyword: 'I think',
+               
+    { keyword: 'I think|We think',
       source:  'http://www.fastcompany.com/3049609/the-future-of-work/4-types-of-useless-phrases-you-need-to-eliminate-from-your-emails',
       message: '"I think" undermines your idea and displays an overall lack of ' +
                'self-confidence. --Lydia Dishman', },
-    { keyword: 'I\'m no expert',
+               
+    { keyword: 'I\'m no expert|We\'re no expert',
       source:  'http://www.fastcompany.com/3049609/the-future-of-work/4-types-of-useless-phrases-you-need-to-eliminate-from-your-emails',
       message: '"I\'m no expert" undermines your idea and displays an overall ' +
               'lack of self-confidence. --Lydia Dishman', },
+    
+    { keyword: 'I would just like to say',
+      source:  'http://www.forbes.com/sites/bonniemarcus/2011/12/09/do-you-sabotage-yourself-by-using-weak-language/#376cd3215787',
+      message: 'You don\'t need permission to say something. Just say it.', },
+    
+    { keyword: 'I would just like',
+      source:  'http://www.forbes.com/sites/bonniemarcus/2011/12/09/do-you-sabotage-yourself-by-using-weak-language/#376cd3215787',
+      message: 'It\'s not necessary to declare your wishes. Just state what you want.', },
+
+    { keyword: 'I would like',
+      source:  'http://www.forbes.com/sites/bonniemarcus/2011/12/09/do-you-sabotage-yourself-by-using-weak-language/#376cd3215787',
+      message: 'Consider omitting this passive phrase unless you truly have ' +
+               'an explicit requirement to request permission for a desire.', },            
+      
+    { keyword: 'Yes, but',
+      source:  'http://www.strategicserendipityforlife.com/documents/Articles/Communication_8TipsForFearlessCommunicationInTheWorkplace.pdf',
+      message: 'You will become an integral part of any team if you are willing ' +
+               ' to build ideas rather than discard them.', },  
+    
+    { keyword: 'literally',
+      source:  'https://expresswriters.com/50-weak-words-and-phrases-to-cut-out-of-your-blogging/',
+      message: 'This is conversational tone and unserious. If something is literal, '+
+               'your readers should know it without you needing to use this word to clarify it.', },  
+    
+    { keyword: 'very',
+      source:  'http://blog.crew.co/5-weak-words-to-avoid/',
+      message: 'Find a stronger, more meaningful adverb, or omit it completely.', },  
+    
+    { keyword: 'interesting',
+      source:  'http://blog.crew.co/5-weak-words-to-avoid/',
+      message: 'Find a stronger, more meaningful adjective, or omit it completely.', },  
+        
+    { keyword: 'I believe',
+      source:  'http://www.forbes.com/sites/bonniemarcus/2011/12/09/do-you-sabotage-yourself-by-using-weak-language/#376cd3215787',
+      message: 'Omit this phrase - whatever you say that follows it is ' + 
+               'what you already beleive.' +
+               'Better Alternatives: I\'m confident, I\'m convinced, I expect, I\'m optimistic', },
+    
+    { keyword: 'I feel',
+      source:  'http://www.forbes.com/sites/bonniemarcus/2011/12/09/do-you-sabotage-yourself-by-using-weak-language/#376cd3215787',
+      message: 'Omit this phrase - whatever you say that follows it is ' + 
+               'may be indeed something you feel, but communication of ' +
+               'feelings discounts any gravitas of the message you want ' +
+               'to convey in a strong manner.', +
+               'Better alternatives: I\'m confident, I\'m convinced, I expect, I\'m optimistic',
+    },
+    
+    { keyword: 'kind of|sort of',
+      source:  'http://www.strategicserendipityforlife.com/documents/Articles/Communication_8TipsForFearlessCommunicationInTheWorkplace.pdf',
+      message: 'This phrases undermine the strength the statement you\'re about '+
+               'to make.',
+    },
+    
     { keyword: 'does that make sense',
       source:  'http://goop.com/how-women-undermine-themselves-with-words/',
       message: '"does that make sense" comes across either as condescending ' +
@@ -35,6 +93,7 @@ var WARNINGS = {
                'to the other party to let you know if they are confused about ' +
                'something, rather than implying that you "didn\'t make sense." ' +
                '--Tara Sophia Mohr', },
+               
     { keyword: 'try|trying',
       source:  'http://www.lifehack.org/articles/communication/7-things-not-to-say-and-7-things-to-start-saying.html',
       message: '"Do or do not. There is no try." --Yoda' },


### PR DESCRIPTION
I've added many conversational, chatty, submissive/passive, empty/vacuous words and phrases to the list which often undermine and weaken the message one is attempting to convey. They're all common phrases and words that I've self-censored myself (as a male), grammar-reviewed and suggested to other men as well as women when I've been asked to proofread high-stakes emails or replies.

On the other hand, there's also a fine line here to tread: sometimes mimicking a superior's conversational or chatty choice of language when the stakes are low is, in my opinion, totally acceptable in moderation. In fact, mimicking another person's (body language) and word/language choice is a commonly understood strategy to establish rapport.

So - in summary, context matters. Not all "sorry-not-sorry" type language needs to be self-censored entirely, but otherwise this tool is a fantastic idea and I hope to see the collection of warnings grow and extend to other programs and interfaces, like desktop email programs (Microsoft Outlook) and office collaboration chat tools such as Slack.

Cheers!